### PR TITLE
add external service task

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This includes all BPMN elements that are wait states and have a boundary for inc
 * Receive Task
 * User Task
 * Event Based Gateway
+* External Service Task
 
 In addition to these elements all activities with asynchronous continuations act as transaction boundaries. This is also valid for multi-instance activities. Learn more about transactions and wait states in the [Camunda documentation](https://docs.camunda.org/manual/latest/user-guide/process-engine/transactions-in-processes/).
 

--- a/lib/TransactionBoundaries.js
+++ b/lib/TransactionBoundaries.js
@@ -67,7 +67,7 @@ TransactionBoundaries.prototype._getTransactionBoundaries = function(element) {
       eventDefinitionType = businessObject.eventDefinitions && businessObject.eventDefinitions[0].$type;
 
   var isWaitStateTask = element.type === 'bpmn:ReceiveTask' || element.type === 'bpmn:UserTask'
-        || ( element.type === 'bpmn:ServiceTask' && businessObject.type === 'external' );
+        || (element.type === 'bpmn:ServiceTask' && businessObject.type === 'external');
 
   var isWaitStateGateway = element.type === 'bpmn:EventBasedGateway';
 

--- a/lib/TransactionBoundaries.js
+++ b/lib/TransactionBoundaries.js
@@ -42,6 +42,7 @@ TransactionBoundaries.$inject = [ 'elementRegistry', 'overlays', 'eventBus' ];
  * - Receive Task
  * - User Task
  * - Event Based Gateway
+ * - External Service Task
  *
  * Furthermore all activities which have asynchronous
  * continuations act as transaction boundaries. This
@@ -65,7 +66,8 @@ TransactionBoundaries.prototype._getTransactionBoundaries = function(element) {
       loopCharacteristics = businessObject.loopCharacteristics,
       eventDefinitionType = businessObject.eventDefinitions && businessObject.eventDefinitions[0].$type;
 
-  var isWaitStateTask = element.type === 'bpmn:ReceiveTask' || element.type === 'bpmn:UserTask';
+  var isWaitStateTask = element.type === 'bpmn:ReceiveTask' || element.type === 'bpmn:UserTask'
+        || ( element.type === 'bpmn:ServiceTask' && businessObject.type === 'external' );
 
   var isWaitStateGateway = element.type === 'bpmn:EventBasedGateway';
 

--- a/test/spec/ExternalServiceTaskSpec.js
+++ b/test/spec/ExternalServiceTaskSpec.js
@@ -1,0 +1,91 @@
+import '../TestHelper';
+
+import Modeler from 'bpmn-js/lib/Modeler';
+
+import transactionBoundariesModule from '../..';
+
+import { forEach } from 'min-dash';
+
+import camundaModdleDescriptor from 'camunda-bpmn-moddle/resources/camunda';
+
+
+describe('transaction-boundaries-external-service-task', function() {
+
+  var diagram = require('./external-service-task.bpmn');
+
+  function withModeler(config, fn) {
+
+    return function(done) {
+
+      var modeler = new Modeler(config);
+
+      modeler.importXML(diagram, function(err) {
+        if (err) {
+          done(err);
+        }
+
+        modeler.invoke(fn);
+
+        done();
+      });
+
+    };
+  }
+
+
+  function inject(fn) {
+
+    var config = {
+      container: 'body',
+      additionalModules: [ transactionBoundariesModule ],
+      moddleExtensions: {
+        camunda: camundaModdleDescriptor
+      }
+    };
+
+    return withModeler(config, fn);
+  }
+
+
+  describe('API', function() {
+
+    it('should show', inject(function(transactionBoundaries, overlays) {
+
+      // when
+      transactionBoundaries.show();
+
+      // then
+      expect(overlays.get({ type: 'transaction-boundaries' })).to.have.length(1);
+
+    }));
+
+  });
+
+
+  describe('unit tests', function() {
+
+    it('get transaction boundary elements', inject(function(transactionBoundaries, elementRegistry) {
+
+      // given
+      var expectedBoundaries = {
+        'ExternalServiceTask': { before: true, after: false }
+      };
+
+      // when
+      var transactionBoundaryElements = transactionBoundaries._getTransactionBoundaryElements();
+
+      // then
+      expect(transactionBoundaryElements).to.have.length(1);
+
+      forEach(transactionBoundaryElements, function(element) {
+
+        var boundaries = expectedBoundaries[element.shape.id];
+
+        expect(boundaries).to.eql(element.boundaries);
+      });
+
+    }));
+
+  });
+
+});

--- a/test/spec/external-service-task.bpmn
+++ b/test/spec/external-service-task.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0wrgih8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.2.3">
+  <bpmn:process id="ExternalServiceTaskProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent" name="external service task to test">
+      <bpmn:outgoing>SequenceFlow_0y0ih9p</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0y0ih9p" sourceRef="StartEvent" targetRef="ExternalServiceTask" />
+    <bpmn:serviceTask id="ExternalServiceTask" name="External service" camunda:type="external" camunda:topic="some topic">
+      <bpmn:incoming>SequenceFlow_0y0ih9p</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0ni87mp</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent" name="external service task tested">
+      <bpmn:incoming>SequenceFlow_1d7xkzf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0ni87mp" sourceRef="ExternalServiceTask" targetRef="Task_1k0u619" />
+    <bpmn:sequenceFlow id="SequenceFlow_1d7xkzf" sourceRef="Task_1k0u619" targetRef="EndEvent" />
+    <bpmn:serviceTask id="Task_1k0u619" name="Delegate service " camunda:delegateExpression="${logger}">
+      <bpmn:incoming>SequenceFlow_0ni87mp</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1d7xkzf</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ExternalServiceTaskProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="152" y="145" width="78" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0y0ih9p_di" bpmnElement="SequenceFlow_0y0ih9p">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="249" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0e6lprm_di" bpmnElement="ExternalServiceTask">
+        <dc:Bounds x="249" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1xqa8rc_di" bpmnElement="EndEvent">
+        <dc:Bounds x="536" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="515" y="145" width="78" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ni87mp_di" bpmnElement="SequenceFlow_0ni87mp">
+        <di:waypoint x="349" y="120" />
+        <di:waypoint x="391" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1d7xkzf_di" bpmnElement="SequenceFlow_1d7xkzf">
+        <di:waypoint x="491" y="120" />
+        <di:waypoint x="536" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0u8pgtq_di" bpmnElement="Task_1k0u619">
+        <dc:Bounds x="391" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Show external service task with a transaction boundary before the task.

Could you please provide a new release and use this in the modeler plugin?

Thank you, Ingo

P.S. Test driven Javascript delevopment is great! 
Writing the test first is so easy with the right blueprint!